### PR TITLE
Add support for Forwarded header in RemoteIpAddress evaluators and GeoIPRemoteAddressEvaluator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When evaluating an `IPAddress` `MatchType`, either the client's socket address o
 
 - `MatchVariable` - the property to retrieve the request's IP address from
   - `SocketAddress` - use the IP address from the actual connection; if the request was previously proxied, this might not be the actual client's address but rather the address of the proxy
-  - `RemoteAddress` - the perceived client's address; at present, this will be the first valid value from the `X-Forwarded-For` header, falling back to the socket address if none was found
+  - `RemoteAddress` - the perceived client's address; at present, this will be the first valid IP address from the `Forwarded` and `X-Forwarded-For` headers, plus the socket address
 - `IPAddressOrRanges` - the IP address(es) to evaluate against, and accepts both IPv4 and IPv6 addresses. This may be either a single IP address, a comma-separated list of IP address, or a CIDR range
 
 ###### Size Evaluators
@@ -133,12 +133,12 @@ The path to a GeoIP2 or GeoLite2 Country database is configured by a `GeoIPDatab
 
 No database files are provided in this project, however one to suit your purpose (commercial, enterprise, or free) can be obtained from MaxMind. Note you will need the _Country_ database, and supplying any other type will fail to load the database and any configured GeoIP evaluators.
 
-Alternatively, other GeoIP databases can be used by implementing the `IGeoIPDatabaseProviderFactory` and `IGeoIPDatabaseProvider` interfaces, and registering them with the service collection with `IFirewallBuilder.Services.TryAddSingleton<IGeoIPDatabaseProviderFactory, YourGeoIPDatabaseProviderFactory>()`. Configuration for your implementation can be done by implementing the `IFirewallConfigurationExtensionProvider` interface (or extneding the `FirewallConfigurationExtensionProvider` class), and registering it with the service collection with `IFirewallBuilder.AddConfigurationExtensionProvider<YourFirewallConfigurationExtensionProvider>()`.
+Alternatively, other GeoIP databases can be used by implementing the `IGeoIPDatabaseProviderFactory` and `IGeoIPDatabaseProvider` interfaces, and registering them with the service collection with `IFirewallBuilder.Services.TryAddSingleton<IGeoIPDatabaseProviderFactory, YourGeoIPDatabaseProviderFactory>()`. Configuration for your implementation can be done by implementing the `IFirewallConfigurationExtensionProvider` interface (or extending the `FirewallConfigurationExtensionProvider` class), and registering it with the service collection with `IFirewallBuilder.AddConfigurationExtensionProvider<YourFirewallConfigurationExtensionProvider>()`.
 (This also works for any other way you would like to extend the firewall functionality.)
 
 ###### Transforms
 
-Tranformations can be applied to the request values for `Size` and `String` evaluators prior to any comparisons to do things like changing the case, trimming whitespace, or applying URL decoding/encoding. `Tranforms` are applied in the order given in the condition configuration.
+Transformations can be applied to the request values for `Size` and `String` evaluators prior to any comparisons to do things like changing the case, trimming whitespace, or applying URL decoding/encoding. `Transforms` are applied in the order given in the condition configuration.
 
 - `Uppercase` - convert the request value to upper-case
 - `Lowercase` - convert the request value to lower-case
@@ -236,6 +236,6 @@ For example, place `"RouteFirewalls"` inside the section used for YARP (eg. `"Re
 }
 ```
 
-# Contributing
+## Contributing
 
 I'm eager to accept contributions and suggestions in any form. Please feel free to open an issue, discussion, or PR, or to message me on here or Mastodon.

--- a/src/Yarp.Extensions.Firewall/Evaluators/SocketIpAddressRangeEvaluator.cs
+++ b/src/Yarp.Extensions.Firewall/Evaluators/SocketIpAddressRangeEvaluator.cs
@@ -33,7 +33,7 @@ public class SocketIpAddressRangeEvaluator(IReadOnlyList<IPNetwork> ipAddressRan
                     context.MatchedValues.Add(new EvaluatorMatchValue(
                         MatchVariableName: "SocketIpAddress",
                         OperatorName: "InRange",
-                        MatchVariableValue: ipAddressRange.ToString()!));
+                        MatchVariableValue: clientAddress.ToString()!));
                     break;
                 }
             }

--- a/src/Yarp.Extensions.Firewall/Utilities/HttpContextExtensions.cs
+++ b/src/Yarp.Extensions.Firewall/Utilities/HttpContextExtensions.cs
@@ -11,9 +11,74 @@ public static class HttpContextExtensions
 {
     /// <summary>
     /// Retrieves the remote <see cref="IPAddress"/> of the client associated with the current request.
-    /// This will be the first valid 'X-Forwarded-For' header if any, falling back to the socket address.
+    /// This will be the first valid 'for' directive in a Forwarded header, if any,
+    /// first falling back to the first valid 'X-Forwarded-For' header, if any,
+    /// then falling back to the socket address.
     /// </summary>
     public static IPAddress? GetRemoteIPAddress(this HttpContext context)
+    {
+        return context.GetRemoteIPAddressFromForwardedHeader()
+            ?? context.GetRemoteIPAddressFromXForwardedForHeader()
+            ?? context.Connection.RemoteIpAddress;
+    }
+
+    /// <summary>
+    /// Retrieves the remote <see cref="IPAddress"/> of the client associated with the current request based on the Forwarded header <c>for</c> directive.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns>
+    /// The first valid IP address found in the header's <c>for</c> directive, otherwise <c>null</c>.
+    /// </returns>
+    public static IPAddress? GetRemoteIPAddressFromForwardedHeader(this HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue("Forwarded", out var header))
+        {
+            foreach (var item in header)
+            {
+                if (string.IsNullOrWhiteSpace(item))
+                {
+                    continue;
+                }
+
+                // directives are ';' separated, but when there is multiple values for the same directive, they are ',' separated
+                var directives = item.Split([';', ','], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                foreach (var directive in directives)
+                {
+                    if (directive.StartsWith("for=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var span = directive.AsSpan(4).Trim('"');
+                        // Forwarded allows for an optional port number after the IP address
+                        // IPAddress.TryParse() will handle this fine for an IPv6 address formatted according to RFC 7239
+                        // but not for IPv4 addresses with a port number
+                        if (span is not ['[', ..])
+                        {
+                            var lastColonIndex = span.LastIndexOf(':');
+                            if (lastColonIndex >= 0)
+                            {
+                                span = span[..lastColonIndex];
+                            }
+                        }
+
+                        if (IPAddress.TryParse(span, out var value))
+                        {
+                            return value;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves the remote <see cref="IPAddress"/> of the client associated with the current request based on the X-Forwarded-For header.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns>
+    /// The first valid IP address found, otherwise <c>null</c>.
+    /// </returns>
+    public static IPAddress? GetRemoteIPAddressFromXForwardedForHeader(this HttpContext context)
     {
         if (context.Request.Headers.TryGetValue("X-Forwarded-For", out var header))
         {
@@ -25,6 +90,7 @@ public static class HttpContextExtensions
                 }
             }
         }
-        return context.Connection.RemoteIpAddress;
+
+        return null;
     }
 }

--- a/test/Yarp.Extensions.Firewall.Tests/Evaluators/IPAddressEvaluatorTests.cs
+++ b/test/Yarp.Extensions.Firewall.Tests/Evaluators/IPAddressEvaluatorTests.cs
@@ -271,8 +271,28 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
             "192.0.2.60"
         },
         {
+            [ new([192, 0, 2, 60]) ],
+            new("for=127.0.0.1, for=192.0.2.60:1006"),
+            "192.0.2.60"
+        },
+        {
+            [ new([192, 0, 2, 60]) ],
+            new(["for=127.0.0.1", "for=192.0.2.60:1006"]),
+            "192.0.2.60"
+        },
+        {
             [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
             new("for=[2001:db8:cafe::17]:4711"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
+            new("for=192.0.2.60:1006, for=[2001:db8:cafe::17]:4711"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
+            new(["for=192.0.2.60:1006", "for=[2001:db8:cafe::17]:4711"]),
             "2001:db8:cafe::17"
         }
     };
@@ -290,8 +310,28 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
             "192.0.2.60"
         },
         {
+            [ new(new IPAddress([192, 0, 0, 0]), 22) ],
+            new("for=127.0.0.1, for=192.0.2.60:1006"),
+            "192.0.2.60"
+        },
+        {
+            [ new(new IPAddress([192, 0, 0, 0]), 22) ],
+            new(["for=127.0.0.1", "for=192.0.2.60:1006"]),
+            "192.0.2.60"
+        },
+        {
             [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
             new("for=[2001:db8:cafe::17]:4711"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
+            new("for=192.0.2.60:1006, for=[2001:db8:cafe::17]:4711"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
+            new(["for=192.0.2.60:1006", "for=[2001:db8:cafe::17]:4711"]),
             "2001:db8:cafe::17"
         }
     };
@@ -302,6 +342,36 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
             [ new([127, 0, 0, 1]) ],
             new("127.0.0.1"),
             "127.0.0.1"
+        },
+        {
+            [ new([192, 0, 2, 60]) ],
+            new("192.0.2.60"),
+            "192.0.2.60"
+        },
+        {
+            [ new([192, 0, 2, 60]) ],
+            new("127.0.0.1, 192.0.2.60"),
+            "192.0.2.60"
+        },
+        {
+            [ new([192, 0, 2, 60]) ],
+            new(["127.0.0.1", "192.0.2.60"]),
+            "192.0.2.60"
+        },
+        {
+            [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
+            new("2001:db8:cafe::17"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
+            new("192.0.2.60:1006, 2001:db8:cafe::17"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
+            new(["192.0.2.60:1006", "2001:db8:cafe::17"]),
+            "2001:db8:cafe::17"
         }
     };
 
@@ -311,6 +381,36 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
             [ new(new IPAddress([127, 0, 0, 1]), 32) ],
             new("127.0.0.1"),
             "127.0.0.1"
+        },
+        {
+            [ new(new IPAddress([192, 0, 0, 0]), 22) ],
+            new("192.0.2.60"),
+            "192.0.2.60"
+        },
+        {
+            [ new(new IPAddress([192, 0, 0, 0]), 22) ],
+            new("127.0.0.1, 192.0.2.60"),
+            "192.0.2.60"
+        },
+        {
+            [ new(new IPAddress([192, 0, 0, 0]), 22) ],
+            new(["127.0.0.1", "192.0.2.60"]),
+            "192.0.2.60"
+        },
+        {
+            [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
+            new("2001:db8:cafe::17"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
+            new("192.0.2.60, 2001:db8:cafe::17"),
+            "2001:db8:cafe::17"
+        },
+        {
+            [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
+            new(["192.0.2.60", "2001:db8:cafe::17"]),
+            "2001:db8:cafe::17"
         }
     };
 }

--- a/test/Yarp.Extensions.Firewall.Tests/Evaluators/IPAddressEvaluatorTests.cs
+++ b/test/Yarp.Extensions.Firewall.Tests/Evaluators/IPAddressEvaluatorTests.cs
@@ -100,8 +100,36 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
     }
 
     [Theory]
+    [MemberData(nameof(ForwardedHeaderAddressData))]
+    public async Task RemoteIpAddressSingleEvaluator_ReturnsTrue_WhenForwardedHeaderMatches(IReadOnlyList<IPAddress> ipAddresses, StringValues forwardedValues, string expectedMatch)
+    {
+        var evaluatorCondition = new IPAddressMatchCondition
+        {
+            MatchVariable = IPMatchVariable.RemoteAddress,
+            IPAddressOrRanges = string.Join(",", ipAddresses),
+        };
+
+        var builderContext = ValidateAndBuild(_ipAddressFactory, evaluatorCondition);
+        var evaluator = Assert.Single(builderContext.RuleConditions);
+
+        Assert.IsType<RemoteIpAddressSingleEvaluator>(evaluator);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("example.com:3456");
+        httpContext.Request.Path = "/";
+        httpContext.Request.Headers.Append("Forwarded", forwardedValues);
+
+        var evalContext = new EvaluationContext(httpContext);
+
+        Assert.True(await evaluator.Evaluate(evalContext, CancellationToken.None));
+        Assert.Single(evalContext.MatchedValues, new EvaluatorMatchValue("RemoteIpAddress", "Equals", expectedMatch));
+    }
+
+    [Theory]
     [MemberData(nameof(XFFHeaderAddressData))]
-    public async Task RemoteIpAddressSingleEvaluator_ReturnsTrue_WhenXForwardedForMatches(IReadOnlyList<IPAddress> ipAddresses, StringValues xForwardedForValues, string expectedMatch)
+    public async Task RemoteIpAddressSingleEvaluator_ReturnsTrue_WhenXForwardedForHeaderMatches(IReadOnlyList<IPAddress> ipAddresses, StringValues xForwardedForValues, string expectedMatch)
     {
         var evaluatorCondition = new IPAddressMatchCondition
         {
@@ -156,8 +184,36 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
     }
 
     [Theory]
+    [MemberData(nameof(ForwardedHeaderRangeData))]
+    public async Task RemoteIpAddressRangeEvaluator_ReturnsTrue_WhenForwardedHeaderMatches(IReadOnlyList<IPNetwork> ipAddressRanges, StringValues forwardedValues, string expectedMatch)
+    {
+        var evaluatorCondition = new IPAddressMatchCondition
+        {
+            MatchVariable = IPMatchVariable.RemoteAddress,
+            IPAddressOrRanges = string.Join(",", ipAddressRanges),
+        };
+
+        var builderContext = ValidateAndBuild(_ipAddressFactory, evaluatorCondition);
+        var evaluator = Assert.Single(builderContext.RuleConditions);
+
+        Assert.IsType<RemoteIpAddressRangeEvaluator>(evaluator);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("example.com:3456");
+        httpContext.Request.Path = "/";
+        httpContext.Request.Headers.AppendList("Forwarded", forwardedValues);
+
+        var evalContext = new EvaluationContext(httpContext);
+
+        Assert.True(await evaluator.Evaluate(evalContext, CancellationToken.None));
+        Assert.Single(evalContext.MatchedValues, new EvaluatorMatchValue("RemoteIpAddress", "InRange", expectedMatch));
+    }
+
+    [Theory]
     [MemberData(nameof(XFFHeaderRangeData))]
-    public async Task RemoteIpAddressRangeEvaluator_ReturnsTrue_WhenXForwardedForMatches(IReadOnlyList<IPNetwork> ipAddressRanges, StringValues xForwardedForValues, string expectedMatch)
+    public async Task RemoteIpAddressRangeEvaluator_ReturnsTrue_WhenXForwardedForHeaderMatches(IReadOnlyList<IPNetwork> ipAddressRanges, StringValues xForwardedForValues, string expectedMatch)
     {
         var evaluatorCondition = new IPAddressMatchCondition
         {
@@ -187,7 +243,7 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
     public static TheoryData<IReadOnlyList<IPAddress>, IPAddress, string> IPAddressData => new()
     {
         {
-            [ new IPAddress([127, 0, 0, 1]) ],
+            [ new([127, 0, 0, 1]) ],
             new([127, 0, 0, 1]),
             "127.0.0.1"
         }
@@ -198,7 +254,45 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
         {
             [ new(new IPAddress([127, 0, 0, 1]), 32) ],
             new([127, 0, 0, 1]),
-            "127.0.0.1/32"
+            "127.0.0.1"
+        }
+    };
+
+    public static TheoryData<IReadOnlyList<IPAddress>, StringValues, string> ForwardedHeaderAddressData => new()
+    {
+        {
+            [ new([127, 0, 0, 1]) ],
+            new("for=127.0.0.1"),
+            "127.0.0.1"
+        },
+        {
+            [ new([192, 0, 2, 60]) ],
+            new("for=192.0.2.60:1006"),
+            "192.0.2.60"
+        },
+        {
+            [ new([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x17]) ],
+            new("for=[2001:db8:cafe::17]:4711"),
+            "2001:db8:cafe::17"
+        }
+    };
+
+    public static TheoryData<IReadOnlyList<IPNetwork>, StringValues, string> ForwardedHeaderRangeData => new()
+    {
+        {
+            [ new(new IPAddress([127, 0, 0, 1]), 32) ],
+            new("for=127.0.0.1"),
+            "127.0.0.1"
+        },
+        {
+            [ new(new IPAddress([192, 0, 0, 0]), 22) ],
+            new("for=192.0.2.60:1006"),
+            "192.0.2.60"
+        },
+        {
+            [ new(new IPAddress([0x20, 0x01, 0x0D, 0xB8, 0xCA, 0xFE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 48) ],
+            new("for=[2001:db8:cafe::17]:4711"),
+            "2001:db8:cafe::17"
         }
     };
 
@@ -216,7 +310,7 @@ public class IPAddressEvaluatorTests : ConditionExtensionsTestsBase
         {
             [ new(new IPAddress([127, 0, 0, 1]), 32) ],
             new("127.0.0.1"),
-            "127.0.0.1/32"
+            "127.0.0.1"
         }
     };
 }


### PR DESCRIPTION
Add support for Forwarded header in RemoteIpAddress evaluators and GeoIPRemoteAddressEvaluator.
Corrected MatchVariableValue to be the actual request value matched rather than the condition value

Closes #25 